### PR TITLE
Adding endpoint findById

### DIFF
--- a/src/main/java/com/jsp/pharmassist/controller/AdminController.java
+++ b/src/main/java/com/jsp/pharmassist/controller/AdminController.java
@@ -1,7 +1,7 @@
 package com.jsp.pharmassist.controller;
 
 
-import com.jsp.pharmassist.entity.Admin;
+
 import com.jsp.pharmassist.requestdtos.AdminRequest;
 import com.jsp.pharmassist.responsedtos.AdminResponse;
 import com.jsp.pharmassist.service.AdminService;
@@ -15,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 public class AdminController {
@@ -44,10 +43,11 @@ public class AdminController {
         return builder.success(HttpStatus.FOUND, "Admins found",response );
     }
 
-    @GetMapping("/{id}")
-    public Optional<Admin> getAdminById(@PathVariable String id) {
-        return adminService.findById(id);
-    }
+    @GetMapping("/admins/{userId}")
+	public ResponseEntity<ResponseStructure<AdminResponse>> findUserById(@PathVariable String userId) {
+    	AdminResponse response = adminService.findAdminById(userId);	
+		return builder.success(HttpStatus.FOUND, "Found successfully", response);
+	}
     
 //    @PutMapping("/{id}")
 //    public Admin updateAdmin(@PathVariable String id, @RequestBody Admin admin) {

--- a/src/main/java/com/jsp/pharmassist/exception/AdminNotFoundByIdException.java
+++ b/src/main/java/com/jsp/pharmassist/exception/AdminNotFoundByIdException.java
@@ -1,0 +1,17 @@
+package com.jsp.pharmassist.exception;
+
+@SuppressWarnings("serial")
+public class AdminNotFoundByIdException extends RuntimeException {
+	
+	private final String message;
+
+	public String getMessage() {
+		return message;
+	}
+
+	public AdminNotFoundByIdException(String message) {
+		super();
+		this.message = message;
+	}
+
+}

--- a/src/main/java/com/jsp/pharmassist/exceptionhandler/AdminExceptionHandler.java
+++ b/src/main/java/com/jsp/pharmassist/exceptionhandler/AdminExceptionHandler.java
@@ -3,11 +3,14 @@ package com.jsp.pharmassist.exceptionhandler;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.jsp.pharmassist.exception.AdminNotFoundByIdException;
 import com.jsp.pharmassist.exception.NoAdminFoundException;
 import com.jsp.pharmassist.util.AppResponseBuilder;
 import com.jsp.pharmassist.util.ErrorStructure;
 
+@RestControllerAdvice
 public class AdminExceptionHandler {
 	
 	private final AppResponseBuilder builder;
@@ -20,6 +23,10 @@ public class AdminExceptionHandler {
 	@ExceptionHandler(NoAdminFoundException.class)
 	public ResponseEntity<ErrorStructure> handleNoAdminFound(NoAdminFoundException ex){
 		return builder.error(HttpStatus.NOT_FOUND, ex.getMessage(), "Admins are not found within the given criteria");
+	}
+	@ExceptionHandler(AdminNotFoundByIdException.class)
+	public ResponseEntity<ErrorStructure> handleUserNotFound(AdminNotFoundByIdException ex){
+		return builder.error(HttpStatus.NOT_FOUND, ex.getMessage(), "User is not found by id");
 	}
 
 }

--- a/src/main/java/com/jsp/pharmassist/mapper/AdminMapper.java
+++ b/src/main/java/com/jsp/pharmassist/mapper/AdminMapper.java
@@ -8,7 +8,7 @@ import com.jsp.pharmassist.responsedtos.AdminResponse;
 
 @Component
 public class AdminMapper {
-	public Admin mapToUser(AdminRequest adminRequest, Admin admin) {
+	public Admin mapToAdmin(AdminRequest adminRequest, Admin admin) {
 		admin.setEmail(adminRequest.getEmail());
 		admin.setPassword(adminRequest.getPassword());
 		admin.setPhoneNo(adminRequest.getPhoneNo());
@@ -16,7 +16,7 @@ public class AdminMapper {
 		return admin;
 	}
 
-	public AdminResponse mapToUserResponse(Admin admin) {
+	public AdminResponse mapToAdminResponse(Admin admin) {
 		AdminResponse response = new AdminResponse();
 		response.setAdminId(admin.getAdminId());
 		response.setEmail(admin.getEmail());

--- a/src/main/java/com/jsp/pharmassist/service/AdminService.java
+++ b/src/main/java/com/jsp/pharmassist/service/AdminService.java
@@ -1,6 +1,8 @@
 package com.jsp.pharmassist.service;
 
+
 import com.jsp.pharmassist.entity.Admin;
+import com.jsp.pharmassist.exception.AdminNotFoundByIdException;
 import com.jsp.pharmassist.mapper.AdminMapper;
 import com.jsp.pharmassist.repository.AdminRepository;
 import com.jsp.pharmassist.requestdtos.AdminRequest;
@@ -32,20 +34,22 @@ public class AdminService {
 	
 
 	public AdminResponse addAdmin(AdminRequest userRequest) {
-		Admin user = adminRepository.save(adminMapper.mapToUser(userRequest, new Admin()));
-		return adminMapper.mapToUserResponse(user);
+		Admin user = adminRepository.save(adminMapper.mapToAdmin(userRequest, new Admin()));
+		return adminMapper.mapToAdminResponse(user);
 	}
 	
 	public List<AdminResponse> findAllAdmins() {
 		return adminRepository.findAll()
 							  .stream()
-							  .map(adminMapper::mapToUserResponse)
+							  .map(adminMapper::mapToAdminResponse)
 							  .toList();
 	}
 
 	
-	public Optional<Admin> findById(String id) {
-		return adminRepository.findById(id);
+	public AdminResponse findAdminById(String adminId) {
+		return adminRepository.findById(adminId)
+				  .map(adminMapper :: mapToAdminResponse)
+				  .orElseThrow(() -> new AdminNotFoundByIdException("Failed to find the user"));
 	}
 
 	public void deleteById(String id) {


### PR DESCRIPTION
###  Feature: Find Admin by ID with Custom Error Handling
## Description
- Service Layer: Added findAdminById method in AdminService that attempts to retrieve an admin by ID. If the admin is not found, it throws a AdminNotFoundByIdException.
 - Custom Exception Handling: Introduced AdminNotFoundByIdException to clearly indicate when an admin is missing. The AdminExceptionHandler catches this exception and returns a 404 Not Found status with a customized error message.
- Standardized Error Response: Used ErrorStructure and AppResponseBuilder to format the error response as:
statuscode: 404
message: "Failed to find the user"
rootCause: "User is not found by id"