### PR TITLE
Delete by Admin Id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.3.5</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.jsp</groupId>
+	<artifactId>PharmacyManagementSystem</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>PharmacyManagementSystem</name>
+	<description>Demo project for Spring Boot</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/main/java/com/jsp/pharmassist/PharmacyManagementSystemApplication.java
+++ b/src/main/java/com/jsp/pharmassist/PharmacyManagementSystemApplication.java
@@ -1,0 +1,13 @@
+package com.jsp.pharmassist;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PharmacyManagementSystemApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(PharmacyManagementSystemApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/jsp/pharmassist/config/CustomIdGenerator.java
+++ b/src/main/java/com/jsp/pharmassist/config/CustomIdGenerator.java
@@ -1,0 +1,17 @@
+package com.jsp.pharmassist.config;
+
+import java.time.Year;
+import java.util.UUID;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.IdentifierGenerator;
+
+public class CustomIdGenerator implements IdentifierGenerator {
+
+	@Override
+	public Object generate(SharedSessionContractImplementor session, Object object) {
+		String str = UUID.randomUUID().toString();
+		return Year.now().toString()+str;
+	}
+
+}

--- a/src/main/java/com/jsp/pharmassist/config/GenerateCustomId.java
+++ b/src/main/java/com/jsp/pharmassist/config/GenerateCustomId.java
@@ -1,0 +1,15 @@
+package com.jsp.pharmassist.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.hibernate.annotations.IdGeneratorType;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@IdGeneratorType(CustomIdGenerator.class)
+public @interface GenerateCustomId {
+
+}

--- a/src/main/java/com/jsp/pharmassist/controller/AdminController.java
+++ b/src/main/java/com/jsp/pharmassist/controller/AdminController.java
@@ -2,6 +2,8 @@ package com.jsp.pharmassist.controller;
 
 import com.jsp.pharmassist.entity.Admin;
 import com.jsp.pharmassist.service.AdminService;
+import com.jsp.pharmassist.util.AppResponseBuilder;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -9,14 +11,17 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/admins")
 public class AdminController {
 
-    @Autowired
     private AdminService adminService;
+    private AppResponseBuilder builder;
+    
+    public AdminController(AdminService adminService, AppResponseBuilder builder) {
+        this.adminService = adminService;
+        this.builder = builder;
+    }
 
-   
-    @PostMapping
+	@PostMapping("/admins")
     public Admin createAdmin(@RequestBody Admin admin) {
         return adminService.save(admin);
     }

--- a/src/main/java/com/jsp/pharmassist/controller/AdminController.java
+++ b/src/main/java/com/jsp/pharmassist/controller/AdminController.java
@@ -30,16 +30,18 @@ public class AdminController {
 		this.builder = builder;
 	}
 
+	
 	@PostMapping("/admins")
 	public ResponseEntity<ResponseStructure<AdminResponse>> createAdmin(@RequestBody @Valid AdminRequest adminRequest) {
 		AdminResponse response = adminService.addAdmin(adminRequest);
-		return builder.success(HttpStatus.CREATED, "Added Successfully", response);
+		return builder.success(HttpStatus.CREATED, "Admin created successfully", response);
 
 	}
     
-    @GetMapping
-    public List<Admin> getAllAdmins() {
-        return adminService.findAll();
+    @GetMapping(value = "/admins")
+    public ResponseEntity<ResponseStructure<List<AdminResponse>>> findAllAdmins() {
+        List<AdminResponse> response = adminService.findAllAdmins();
+        return builder.success(HttpStatus.FOUND, "Admins found",response );
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/jsp/pharmassist/controller/AdminController.java
+++ b/src/main/java/com/jsp/pharmassist/controller/AdminController.java
@@ -15,6 +15,12 @@ public class AdminController {
     @Autowired
     private AdminService adminService;
 
+   
+    @PostMapping
+    public Admin createAdmin(@RequestBody Admin admin) {
+        return adminService.save(admin);
+    }
+    
     @GetMapping
     public List<Admin> getAllAdmins() {
         return adminService.findAll();
@@ -24,12 +30,7 @@ public class AdminController {
     public Optional<Admin> getAdminById(@PathVariable String id) {
         return adminService.findById(id);
     }
-
-    @PostMapping
-    public Admin createAdmin(@RequestBody Admin admin) {
-        return adminService.save(admin);
-    }
-
+    
     @PutMapping("/{id}")
     public Admin updateAdmin(@PathVariable String id, @RequestBody Admin admin) {
         admin.setAdminId(id);

--- a/src/main/java/com/jsp/pharmassist/controller/AdminController.java
+++ b/src/main/java/com/jsp/pharmassist/controller/AdminController.java
@@ -1,10 +1,17 @@
 package com.jsp.pharmassist.controller;
 
+
 import com.jsp.pharmassist.entity.Admin;
+import com.jsp.pharmassist.requestdtos.AdminRequest;
+import com.jsp.pharmassist.responsedtos.AdminResponse;
 import com.jsp.pharmassist.service.AdminService;
 import com.jsp.pharmassist.util.AppResponseBuilder;
+import com.jsp.pharmassist.util.ResponseStructure;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -13,18 +20,22 @@ import java.util.Optional;
 @RestController
 public class AdminController {
 
-    private AdminService adminService;
-    private AppResponseBuilder builder;
-    
-    public AdminController(AdminService adminService, AppResponseBuilder builder) {
-        this.adminService = adminService;
-        this.builder = builder;
-    }
+    private final AdminService adminService;
+    private final AppResponseBuilder builder;
+  
+
+	public AdminController(AdminService adminService, AppResponseBuilder builder) {
+		super();
+		this.adminService = adminService;
+		this.builder = builder;
+	}
 
 	@PostMapping("/admins")
-    public Admin createAdmin(@RequestBody Admin admin) {
-        return adminService.save(admin);
-    }
+	public ResponseEntity<ResponseStructure<AdminResponse>> createAdmin(@RequestBody @Valid AdminRequest adminRequest) {
+		AdminResponse response = adminService.addAdmin(adminRequest);
+		return builder.success(HttpStatus.CREATED, "Added Successfully", response);
+
+	}
     
     @GetMapping
     public List<Admin> getAllAdmins() {
@@ -36,11 +47,11 @@ public class AdminController {
         return adminService.findById(id);
     }
     
-    @PutMapping("/{id}")
-    public Admin updateAdmin(@PathVariable String id, @RequestBody Admin admin) {
-        admin.setAdminId(id);
-        return adminService.save(admin);
-    }
+//    @PutMapping("/{id}")
+//    public Admin updateAdmin(@PathVariable String id, @RequestBody Admin admin) {
+//        admin.setAdminId(id);
+//        return adminService.save(admin);
+//    }
 
     @DeleteMapping("/{id}")
     public void deleteAdmin(@PathVariable String id) {

--- a/src/main/java/com/jsp/pharmassist/controller/AdminController.java
+++ b/src/main/java/com/jsp/pharmassist/controller/AdminController.java
@@ -1,7 +1,7 @@
 package com.jsp.pharmassist.controller;
 
 
-import com.jsp.pharmassist.entity.Admin;
+
 import com.jsp.pharmassist.requestdtos.AdminRequest;
 import com.jsp.pharmassist.responsedtos.AdminResponse;
 import com.jsp.pharmassist.service.AdminService;
@@ -15,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 public class AdminController {
@@ -44,10 +43,11 @@ public class AdminController {
         return builder.success(HttpStatus.FOUND, "Admins found",response );
     }
 
-    @GetMapping("/{id}")
-    public Optional<Admin> getAdminById(@PathVariable String id) {
-        return adminService.findById(id);
-    }
+    @GetMapping("/admins/{userId}")
+	public ResponseEntity<ResponseStructure<AdminResponse>> findUserById(@PathVariable String userId) {
+    	AdminResponse response = adminService.findAdminById(userId);	
+		return builder.success(HttpStatus.FOUND, "Found successfully", response);
+	}
     
 //    @PutMapping("/{id}")
 //    public Admin updateAdmin(@PathVariable String id, @RequestBody Admin admin) {

--- a/src/main/java/com/jsp/pharmassist/controller/AdminController.java
+++ b/src/main/java/com/jsp/pharmassist/controller/AdminController.java
@@ -1,0 +1,43 @@
+package com.jsp.pharmassist.controller;
+
+import com.jsp.pharmassist.entity.Admin;
+import com.jsp.pharmassist.service.AdminService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/admins")
+public class AdminController {
+
+    @Autowired
+    private AdminService adminService;
+
+    @GetMapping
+    public List<Admin> getAllAdmins() {
+        return adminService.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public Optional<Admin> getAdminById(@PathVariable String id) {
+        return adminService.findById(id);
+    }
+
+    @PostMapping
+    public Admin createAdmin(@RequestBody Admin admin) {
+        return adminService.save(admin);
+    }
+
+    @PutMapping("/{id}")
+    public Admin updateAdmin(@PathVariable String id, @RequestBody Admin admin) {
+        admin.setAdminId(id);
+        return adminService.save(admin);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteAdmin(@PathVariable String id) {
+        adminService.deleteById(id);
+    }
+}

--- a/src/main/java/com/jsp/pharmassist/entity/Admin.java
+++ b/src/main/java/com/jsp/pharmassist/entity/Admin.java
@@ -1,9 +1,12 @@
 package com.jsp.pharmassist.entity;
 
+import com.jsp.pharmassist.config.GenerateCustomId;
+
 import jakarta.persistence.Id;
 
 public class Admin {
 	@Id
+	@GenerateCustomId
 	private String adminId;
 	private String email;
 	private String phoneNo;

--- a/src/main/java/com/jsp/pharmassist/entity/Admin.java
+++ b/src/main/java/com/jsp/pharmassist/entity/Admin.java
@@ -2,8 +2,9 @@ package com.jsp.pharmassist.entity;
 
 import com.jsp.pharmassist.config.GenerateCustomId;
 
+import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-
+@Entity
 public class Admin {
 	@Id
 	@GenerateCustomId

--- a/src/main/java/com/jsp/pharmassist/entity/Admin.java
+++ b/src/main/java/com/jsp/pharmassist/entity/Admin.java
@@ -1,0 +1,39 @@
+package com.jsp.pharmassist.entity;
+
+import jakarta.persistence.Id;
+
+public class Admin {
+	@Id
+	private String adminId;
+	private String email;
+	private String phoneNo;
+	private String password;
+	
+	public String getAdminId() {
+		return adminId;
+	}
+	public void setAdminId(String adminId) {
+		this.adminId = adminId;
+	}
+	public String getEmail() {
+		return email;
+	}
+	public void setEmail(String email) {
+		this.email = email;
+	}
+	public String getPhoneNo() {
+		return phoneNo;
+	}
+	public void setPhoneNo(String phoneNo) {
+		this.phoneNo = phoneNo;
+	}
+	public String getPassword() {
+		return password;
+	}
+	public void setPassword(String password) {
+		this.password = password;
+	}
+	
+	
+
+}

--- a/src/main/java/com/jsp/pharmassist/exception/AdminNotFoundByIdException.java
+++ b/src/main/java/com/jsp/pharmassist/exception/AdminNotFoundByIdException.java
@@ -1,0 +1,17 @@
+package com.jsp.pharmassist.exception;
+
+@SuppressWarnings("serial")
+public class AdminNotFoundByIdException extends RuntimeException {
+	
+	private final String message;
+
+	public String getMessage() {
+		return message;
+	}
+
+	public AdminNotFoundByIdException(String message) {
+		super();
+		this.message = message;
+	}
+
+}

--- a/src/main/java/com/jsp/pharmassist/exception/NoAdminFoundException.java
+++ b/src/main/java/com/jsp/pharmassist/exception/NoAdminFoundException.java
@@ -1,0 +1,19 @@
+package com.jsp.pharmassist.exception;
+
+public class NoAdminFoundException extends RuntimeException{
+	
+	private final String message;
+
+	public String getMessage() {
+		return message;
+	}
+
+	public NoAdminFoundException(String message) {
+		super();
+		this.message = message;
+	}
+
+	
+	
+
+}

--- a/src/main/java/com/jsp/pharmassist/exceptionhandler/AdminExceptionHandler.java
+++ b/src/main/java/com/jsp/pharmassist/exceptionhandler/AdminExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.jsp.pharmassist.exceptionhandler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import com.jsp.pharmassist.exception.NoAdminFoundException;
+import com.jsp.pharmassist.util.AppResponseBuilder;
+import com.jsp.pharmassist.util.ErrorStructure;
+
+public class AdminExceptionHandler {
+	
+	private final AppResponseBuilder builder;
+
+	public AdminExceptionHandler(AppResponseBuilder builder) {
+		super();
+		this.builder = builder;
+	}
+	
+	@ExceptionHandler(NoAdminFoundException.class)
+	public ResponseEntity<ErrorStructure> handleNoAdminFound(NoAdminFoundException ex){
+		return builder.error(HttpStatus.NOT_FOUND, ex.getMessage(), "Admins are not found within the given criteria");
+	}
+
+}

--- a/src/main/java/com/jsp/pharmassist/exceptionhandler/AdminExceptionHandler.java
+++ b/src/main/java/com/jsp/pharmassist/exceptionhandler/AdminExceptionHandler.java
@@ -3,11 +3,14 @@ package com.jsp.pharmassist.exceptionhandler;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.jsp.pharmassist.exception.AdminNotFoundByIdException;
 import com.jsp.pharmassist.exception.NoAdminFoundException;
 import com.jsp.pharmassist.util.AppResponseBuilder;
 import com.jsp.pharmassist.util.ErrorStructure;
 
+@RestControllerAdvice
 public class AdminExceptionHandler {
 	
 	private final AppResponseBuilder builder;
@@ -20,6 +23,10 @@ public class AdminExceptionHandler {
 	@ExceptionHandler(NoAdminFoundException.class)
 	public ResponseEntity<ErrorStructure> handleNoAdminFound(NoAdminFoundException ex){
 		return builder.error(HttpStatus.NOT_FOUND, ex.getMessage(), "Admins are not found within the given criteria");
+	}
+	@ExceptionHandler(AdminNotFoundByIdException.class)
+	public ResponseEntity<ErrorStructure> handleUserNotFound(AdminNotFoundByIdException ex){
+		return builder.error(HttpStatus.NOT_FOUND, ex.getMessage(), "User is not found by id");
 	}
 
 }

--- a/src/main/java/com/jsp/pharmassist/exceptionhandler/FieldErrorExceptionHandler.java
+++ b/src/main/java/com/jsp/pharmassist/exceptionhandler/FieldErrorExceptionHandler.java
@@ -16,8 +16,6 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 import com.jsp.pharmassist.util.ErrorStructure;
 
-
-
 @RestControllerAdvice
 public class FieldErrorExceptionHandler extends ResponseEntityExceptionHandler{
 	

--- a/src/main/java/com/jsp/pharmassist/exceptionhandler/FieldErrorExceptionHandler.java
+++ b/src/main/java/com/jsp/pharmassist/exceptionhandler/FieldErrorExceptionHandler.java
@@ -1,0 +1,69 @@
+package com.jsp.pharmassist.exceptionhandler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import com.jsp.pharmassist.util.ErrorStructure;
+
+
+
+@RestControllerAdvice
+public class FieldErrorExceptionHandler extends ResponseEntityExceptionHandler{
+	
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+			HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+		List<ObjectError> errors = ex.getAllErrors();
+		
+		List<FieldErrorStructure> errorResponse = new ArrayList<>();
+		for(ObjectError error:errors) {
+			FieldError fr = (FieldError) error;
+			String message = fr.getDefaultMessage();
+			String field = fr.getField();
+			Object rejectedValue = fr.getRejectedValue();
+			
+			FieldErrorStructure fieldErrorStructure = new FieldErrorStructure(message, field, rejectedValue);
+			errorResponse.add(fieldErrorStructure);
+		}
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+				.body(ErrorStructure.create(HttpStatus.BAD_REQUEST.value(), "Invalid input",errorResponse ));
+	}
+	
+	class FieldErrorStructure{
+		private String message;
+		private String field;
+		private Object rejectedValue;
+		
+		
+		public FieldErrorStructure(String message, String field, Object rejectedValue) {
+			super();
+			this.message = message;
+			this.field = field;
+			this.rejectedValue = rejectedValue;
+		}
+		
+		public String getMessage() {
+			return message;
+		}
+		public String getField() {
+			return field;
+		}
+		public Object getRejectedValue() {
+			return rejectedValue;
+		}
+		
+		
+	}
+
+}

--- a/src/main/java/com/jsp/pharmassist/mapper/AdminMapper.java
+++ b/src/main/java/com/jsp/pharmassist/mapper/AdminMapper.java
@@ -1,9 +1,12 @@
 package com.jsp.pharmassist.mapper;
 
+import org.springframework.stereotype.Component;
+
 import com.jsp.pharmassist.entity.Admin;
 import com.jsp.pharmassist.requestdtos.AdminRequest;
 import com.jsp.pharmassist.responsedtos.AdminResponse;
 
+@Component
 public class AdminMapper {
 	public Admin mapToUser(AdminRequest adminRequest, Admin admin) {
 		admin.setEmail(adminRequest.getEmail());
@@ -17,6 +20,7 @@ public class AdminMapper {
 		AdminResponse response = new AdminResponse();
 		response.setAdminId(admin.getAdminId());
 		response.setEmail(admin.getEmail());
+		response.setPhoneNo(admin.getPhoneNo());
 
 		return response;
 	}

--- a/src/main/java/com/jsp/pharmassist/mapper/AdminMapper.java
+++ b/src/main/java/com/jsp/pharmassist/mapper/AdminMapper.java
@@ -8,7 +8,7 @@ import com.jsp.pharmassist.responsedtos.AdminResponse;
 
 @Component
 public class AdminMapper {
-	public Admin mapToUser(AdminRequest adminRequest, Admin admin) {
+	public Admin mapToAdmin(AdminRequest adminRequest, Admin admin) {
 		admin.setEmail(adminRequest.getEmail());
 		admin.setPassword(adminRequest.getPassword());
 		admin.setPhoneNo(adminRequest.getPhoneNo());
@@ -16,7 +16,7 @@ public class AdminMapper {
 		return admin;
 	}
 
-	public AdminResponse mapToUserResponse(Admin admin) {
+	public AdminResponse mapToAdminResponse(Admin admin) {
 		AdminResponse response = new AdminResponse();
 		response.setAdminId(admin.getAdminId());
 		response.setEmail(admin.getEmail());

--- a/src/main/java/com/jsp/pharmassist/mapper/AdminMapper.java
+++ b/src/main/java/com/jsp/pharmassist/mapper/AdminMapper.java
@@ -1,0 +1,24 @@
+package com.jsp.pharmassist.mapper;
+
+import com.jsp.pharmassist.entity.Admin;
+import com.jsp.pharmassist.requestdtos.AdminRequest;
+import com.jsp.pharmassist.responsedtos.AdminResponse;
+
+public class AdminMapper {
+	public Admin mapToUser(AdminRequest adminRequest, Admin admin) {
+		admin.setEmail(adminRequest.getEmail());
+		admin.setPassword(adminRequest.getPassword());
+		admin.setPhoneNo(adminRequest.getPhoneNo());
+
+		return admin;
+	}
+
+	public AdminResponse mapToUserResponse(Admin admin) {
+		AdminResponse response = new AdminResponse();
+		response.setAdminId(admin.getAdminId());
+		response.setEmail(admin.getEmail());
+
+		return response;
+	}
+
+}

--- a/src/main/java/com/jsp/pharmassist/repository/AdminRepository.java
+++ b/src/main/java/com/jsp/pharmassist/repository/AdminRepository.java
@@ -1,0 +1,11 @@
+package com.jsp.pharmassist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.jsp.pharmassist.entity.Admin;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, String> {
+}
+

--- a/src/main/java/com/jsp/pharmassist/requestdtos/AdminRequest.java
+++ b/src/main/java/com/jsp/pharmassist/requestdtos/AdminRequest.java
@@ -1,0 +1,43 @@
+package com.jsp.pharmassist.requestdtos;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public class AdminRequest {
+	
+	@NotNull(message = "password can not be null")
+	@NotBlank(message = "password can not be blank")
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,12}$", 
+	    message = "Password must contain at least 1 uppercase, 1 lowercase, 1 special character, 1 number, and have a length between 8 to 12 characters.")
+	private String password;
+
+	@NotNull(message = "email can not be null")
+	@NotBlank(message = "email can not be blank")
+	@Pattern(regexp = "^[a-z0-9._%+-]+@gmail\\.com$", message = "Invalid Gmail address")
+	private String email;
+
+	@NotNull(message = "phoneNo can not be null")
+	@NotBlank(message = "phoneNo can not be blank")
+	@Pattern(regexp = "^[6-9]\\d{9}$", message = "Invalid Phone Number")
+	private String phoneNo;
+
+	public String getEmail() {
+		return email;
+	}
+	public void setEmail(String email) {
+		this.email = email;
+	}
+	public String getPhoneNo() {
+		return phoneNo;
+	}
+	public void setPhoneNo(String phoneNo) {
+		this.phoneNo = phoneNo;
+	}
+	public String getPassword() {
+		return password;
+	}
+	public void setPassword(String password) {
+		this.password = password;
+	}
+}

--- a/src/main/java/com/jsp/pharmassist/responsedtos/AdminResponse.java
+++ b/src/main/java/com/jsp/pharmassist/responsedtos/AdminResponse.java
@@ -1,0 +1,29 @@
+package com.jsp.pharmassist.responsedtos;
+
+public class AdminResponse {
+	private String adminId;
+	private String email;
+	private String phoneNo;
+	
+	public String getAdminId() {
+		return adminId;
+	}
+	public void setAdminId(String adminId) {
+		this.adminId = adminId;
+	}
+	public String getEmail() {
+		return email;
+	}
+	public void setEmail(String email) {
+		this.email = email;
+	}
+	public String getPhoneNo() {
+		return phoneNo;
+	}
+	public void setPhoneNo(String phoneNo) {
+		this.phoneNo = phoneNo;
+	}
+	
+	
+
+}

--- a/src/main/java/com/jsp/pharmassist/service/AdminService.java
+++ b/src/main/java/com/jsp/pharmassist/service/AdminService.java
@@ -1,8 +1,17 @@
 package com.jsp.pharmassist.service;
 
+
+
 import com.jsp.pharmassist.entity.Admin;
+import com.jsp.pharmassist.mapper.AdminMapper;
 import com.jsp.pharmassist.repository.AdminRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.jsp.pharmassist.requestdtos.AdminRequest;
+import com.jsp.pharmassist.responsedtos.AdminResponse;
+import com.jsp.pharmassist.util.AppResponseBuilder;
+import com.jsp.pharmassist.util.ResponseStructure;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -11,22 +20,33 @@ import java.util.Optional;
 @Service
 public class AdminService {
 
-    @Autowired
-    private AdminRepository adminRepository;
+	private final AdminRepository adminRepository;
+	private final AppResponseBuilder appResponseBuilder;
+	private final AdminMapper adminMapper;
 
-    public List<Admin> findAll() {
-        return adminRepository.findAll();
-    }
 
-    public Optional<Admin> findById(String id) {
-        return adminRepository.findById(id);
-    }
+	public AdminService(AdminRepository adminRepository, AppResponseBuilder appResponseBuilder,
+			AdminMapper adminMapper) {
+		super();
+		this.adminRepository = adminRepository;
+		this.appResponseBuilder = appResponseBuilder;
+		this.adminMapper = adminMapper;
+	}
 
-    public Admin save(Admin admin) {
-        return adminRepository.save(admin);
-    }
+	public AdminResponse addAdmin(AdminRequest userRequest) {
+		Admin user = adminRepository.save(adminMapper.mapToUser(userRequest, new Admin()));
+		return adminMapper.mapToUserResponse(user);
+	}
+	
+	public List<Admin> findAll() {
+		return adminRepository.findAll();
+	}
 
-    public void deleteById(String id) {
-        adminRepository.deleteById(id);
-    }
+	public Optional<Admin> findById(String id) {
+		return adminRepository.findById(id);
+	}
+
+	public void deleteById(String id) {
+		adminRepository.deleteById(id);
+	}
 }

--- a/src/main/java/com/jsp/pharmassist/service/AdminService.java
+++ b/src/main/java/com/jsp/pharmassist/service/AdminService.java
@@ -1,0 +1,32 @@
+package com.jsp.pharmassist.service;
+
+import com.jsp.pharmassist.entity.Admin;
+import com.jsp.pharmassist.repository.AdminRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class AdminService {
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    public List<Admin> findAll() {
+        return adminRepository.findAll();
+    }
+
+    public Optional<Admin> findById(String id) {
+        return adminRepository.findById(id);
+    }
+
+    public Admin save(Admin admin) {
+        return adminRepository.save(admin);
+    }
+
+    public void deleteById(String id) {
+        adminRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/jsp/pharmassist/service/AdminService.java
+++ b/src/main/java/com/jsp/pharmassist/service/AdminService.java
@@ -1,6 +1,8 @@
 package com.jsp.pharmassist.service;
 
+
 import com.jsp.pharmassist.entity.Admin;
+import com.jsp.pharmassist.exception.AdminNotFoundByIdException;
 import com.jsp.pharmassist.mapper.AdminMapper;
 import com.jsp.pharmassist.repository.AdminRepository;
 import com.jsp.pharmassist.requestdtos.AdminRequest;
@@ -32,20 +34,22 @@ public class AdminService {
 	
 
 	public AdminResponse addAdmin(AdminRequest userRequest) {
-		Admin user = adminRepository.save(adminMapper.mapToUser(userRequest, new Admin()));
-		return adminMapper.mapToUserResponse(user);
+		Admin user = adminRepository.save(adminMapper.mapToAdmin(userRequest, new Admin()));
+		return adminMapper.mapToAdminResponse(user);
 	}
 	
 	public List<AdminResponse> findAllAdmins() {
 		return adminRepository.findAll()
 							  .stream()
-							  .map(adminMapper::mapToUserResponse)
+							  .map(adminMapper::mapToAdminResponse)
 							  .toList();
 	}
 
 	
-	public Optional<Admin> findById(String id) {
-		return adminRepository.findById(id);
+	public AdminResponse findAdminById(String adminId) {
+		return adminRepository.findById(adminId)
+				  .map(adminMapper :: mapToAdminResponse)
+				  .orElseThrow(() -> new AdminNotFoundByIdException("Failed to find the user"));
 	}
 
 	public void deleteById(String id) {

--- a/src/main/java/com/jsp/pharmassist/service/AdminService.java
+++ b/src/main/java/com/jsp/pharmassist/service/AdminService.java
@@ -1,7 +1,5 @@
 package com.jsp.pharmassist.service;
 
-
-
 import com.jsp.pharmassist.entity.Admin;
 import com.jsp.pharmassist.mapper.AdminMapper;
 import com.jsp.pharmassist.repository.AdminRepository;
@@ -24,7 +22,6 @@ public class AdminService {
 	private final AppResponseBuilder appResponseBuilder;
 	private final AdminMapper adminMapper;
 
-
 	public AdminService(AdminRepository adminRepository, AppResponseBuilder appResponseBuilder,
 			AdminMapper adminMapper) {
 		super();
@@ -32,16 +29,21 @@ public class AdminService {
 		this.appResponseBuilder = appResponseBuilder;
 		this.adminMapper = adminMapper;
 	}
+	
 
 	public AdminResponse addAdmin(AdminRequest userRequest) {
 		Admin user = adminRepository.save(adminMapper.mapToUser(userRequest, new Admin()));
 		return adminMapper.mapToUserResponse(user);
 	}
 	
-	public List<Admin> findAll() {
-		return adminRepository.findAll();
+	public List<AdminResponse> findAllAdmins() {
+		return adminRepository.findAll()
+							  .stream()
+							  .map(adminMapper::mapToUserResponse)
+							  .toList();
 	}
 
+	
 	public Optional<Admin> findById(String id) {
 		return adminRepository.findById(id);
 	}

--- a/src/main/java/com/jsp/pharmassist/util/AppResponseBuilder.java
+++ b/src/main/java/com/jsp/pharmassist/util/AppResponseBuilder.java
@@ -1,0 +1,23 @@
+package com.jsp.pharmassist.util;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class AppResponseBuilder {
+	
+	public <T> ResponseEntity<ResponseStructure<T>> success(HttpStatus status, String message,T data){
+		
+		return ResponseEntity.status(status)
+				.body(ResponseStructure.create(status, message, data)); 
+	}
+	
+	public  ResponseEntity<ErrorStructure> error(HttpStatus status, String message, String rootCause){
+		
+		return ResponseEntity.status(status)
+				.body(ErrorStructure.create(status.value(), message, rootCause));
+	}
+
+}

--- a/src/main/java/com/jsp/pharmassist/util/ErrorStructure.java
+++ b/src/main/java/com/jsp/pharmassist/util/ErrorStructure.java
@@ -1,0 +1,40 @@
+package com.jsp.pharmassist.util;
+
+
+public class ErrorStructure<T> {
+	
+	private int statuscode;
+	private String message;
+	private T rootCause;
+	
+	public int getStatuscode() {
+		return statuscode;
+	}
+	public void setStatuscode(int statuscode) {
+		this.statuscode = statuscode;
+	}
+	public String getMessage() {
+		return message;
+	}
+	public void setMessage(String message) {
+		this.message = message;
+	}
+	public T getRootCause() {
+		return rootCause;
+	}
+	public void setRootCause(T rootCause) {
+		this.rootCause = rootCause;
+	}
+	
+	public static <T> ErrorStructure<T> create(int status, String message, T rootCause) {
+		
+		ErrorStructure<T> error = new ErrorStructure<T>();
+		error.setStatuscode(status);
+		error.setMessage(message);
+		error.setRootCause(rootCause);
+		
+		return error;
+	}
+	
+
+}

--- a/src/main/java/com/jsp/pharmassist/util/ResponseStructure.java
+++ b/src/main/java/com/jsp/pharmassist/util/ResponseStructure.java
@@ -26,10 +26,10 @@ public class ResponseStructure<T> {
 		this.data = data;
 	}
 
-	public static <T> ResponseStructure<T> create(HttpStatus status,String message, T user){
+	public static <T> ResponseStructure<T> create(HttpStatus status,String message, T admin){
 		
 		ResponseStructure<T> structure = new ResponseStructure<T>();
-		structure.setData(user);
+		structure.setData(admin);
 		structure.setMessage(message);
 		structure.setStatuscode(status.value());
 		

--- a/src/main/java/com/jsp/pharmassist/util/ResponseStructure.java
+++ b/src/main/java/com/jsp/pharmassist/util/ResponseStructure.java
@@ -1,0 +1,38 @@
+package com.jsp.pharmassist.util;
+
+import org.springframework.http.HttpStatus;
+
+public class ResponseStructure<T> {
+	private int statuscode;
+	private String message;
+	private T data;
+	
+	public int getStatuscode() {
+		return statuscode;
+	}
+	public void setStatuscode(int statuscode) {
+		this.statuscode = statuscode;
+	}
+	public String getMessage() {
+		return message;
+	}
+	public void setMessage(String message) {
+		this.message = message;
+	}
+	public T getData() {
+		return data;
+	}
+	public void setData(T data) {
+		this.data = data;
+	}
+
+	public static <T> ResponseStructure<T> create(HttpStatus status,String message, T user){
+		
+		ResponseStructure<T> structure = new ResponseStructure<T>();
+		structure.setData(user);
+		structure.setMessage(message);
+		structure.setStatuscode(status.value());
+		
+		return structure;
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,13 @@
-spring.application.name=PharmacyManagementSystem
+
+#DATASOURCE CONFIGURATION
+spring.datasource.url= jdbc:mysql://localhost:3306/springboot_pharmassist?createDatabaseIfNotExist=true
+spring.datasource.username=root
+spring.datasource.password=Mysql@123
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+#SERVER CONFIGURATION
+server.port=7000
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=PharmacyManagementSystem

--- a/src/test/java/com/jsp/pharmassist/PharmacyManagementSystemApplicationTests.java
+++ b/src/test/java/com/jsp/pharmassist/PharmacyManagementSystemApplicationTests.java
@@ -1,0 +1,13 @@
+package com.jsp.pharmassist;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PharmacyManagementSystemApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
### Feature: Delete Admin by ID with Custom Error Handling
## Description
- Service Layer: Added deleteAdminById method in AdminService that deletes an admin by ID if they exist. If the ID does not exist, the method throws a AdminNotFoundByIdException.
- Custom Exception Handling: Enhanced AdminExceptionHandler to catch AdminNotFoundByIdException and return a 404 Not Found status with a descriptive error message.
- Consistent Response Structure: Used ErrorStructure and AppResponseBuilder to return a structured response for both successful and failed delete operations:
Success: Returns 200 OK with a success message.
Failure: Returns 404 Not Found with an error structure:
statuscode: 404
message: "Failed to find the user"
rootCause: "User is not found by id"