### PR TITLE
Adding endpoint deleteById

### DIFF
--- a/src/main/java/com/jsp/pharmassist/controller/AdminController.java
+++ b/src/main/java/com/jsp/pharmassist/controller/AdminController.java
@@ -1,7 +1,5 @@
 package com.jsp.pharmassist.controller;
 
-
-
 import com.jsp.pharmassist.requestdtos.AdminRequest;
 import com.jsp.pharmassist.responsedtos.AdminResponse;
 import com.jsp.pharmassist.service.AdminService;
@@ -43,20 +41,18 @@ public class AdminController {
         return builder.success(HttpStatus.FOUND, "Admins found",response );
     }
 
-    @GetMapping("/admins/{userId}")
-	public ResponseEntity<ResponseStructure<AdminResponse>> findUserById(@PathVariable String userId) {
-    	AdminResponse response = adminService.findAdminById(userId);	
+    @GetMapping("/admins/{adminId}")
+	public ResponseEntity<ResponseStructure<AdminResponse>> findAdminById(@PathVariable String adminId) {
+    	AdminResponse response = adminService.findAdminById(adminId);	
 		return builder.success(HttpStatus.FOUND, "Found successfully", response);
 	}
     
-//    @PutMapping("/{id}")
-//    public Admin updateAdmin(@PathVariable String id, @RequestBody Admin admin) {
-//        admin.setAdminId(id);
-//        return adminService.save(admin);
-//    }
+    
 
-    @DeleteMapping("/{id}")
-    public void deleteAdmin(@PathVariable String id) {
-        adminService.deleteById(id);
-    }
+    @DeleteMapping("/admins/{adminId}")
+	public ResponseEntity<ResponseStructure<AdminResponse>> deleteAdminById(@PathVariable String adminId){
+    	AdminResponse response = adminService.deleteAdminById(adminId);
+		return builder.success(HttpStatus.OK, "Deleted successfully", response);
+
+	}
 }

--- a/src/main/java/com/jsp/pharmassist/service/AdminService.java
+++ b/src/main/java/com/jsp/pharmassist/service/AdminService.java
@@ -31,28 +31,38 @@ public class AdminService {
 		this.appResponseBuilder = appResponseBuilder;
 		this.adminMapper = adminMapper;
 	}
-	
+
 
 	public AdminResponse addAdmin(AdminRequest userRequest) {
 		Admin user = adminRepository.save(adminMapper.mapToAdmin(userRequest, new Admin()));
 		return adminMapper.mapToAdminResponse(user);
 	}
-	
+
 	public List<AdminResponse> findAllAdmins() {
 		return adminRepository.findAll()
-							  .stream()
-							  .map(adminMapper::mapToAdminResponse)
-							  .toList();
+				.stream()
+				.map(adminMapper::mapToAdminResponse)
+				.toList();
+	}
+
+
+	public AdminResponse findAdminById(String adminId) {
+		return adminRepository.findById(adminId)
+				.map(adminMapper :: mapToAdminResponse)
+				.orElseThrow(() -> new AdminNotFoundByIdException("Failed to find the user"));
 	}
 
 	
-	public AdminResponse findAdminById(String adminId) {
-		return adminRepository.findById(adminId)
-				  .map(adminMapper :: mapToAdminResponse)
-				  .orElseThrow(() -> new AdminNotFoundByIdException("Failed to find the user"));
-	}
 
-	public void deleteById(String id) {
-		adminRepository.deleteById(id);
+
+	public AdminResponse deleteAdminById(String adminId) {
+
+		return adminRepository.findById(adminId)
+				.map(user ->{
+					adminRepository.delete(user);
+					return user;
+				})
+				.map(adminMapper :: mapToAdminResponse)
+				.orElseThrow(() ->new AdminNotFoundByIdException("Failed to Delete the user"));
 	}
 }


### PR DESCRIPTION
### Feature: Delete Admin by ID with Custom Error Handling
## Description
- Service Layer: Added deleteAdminById method in AdminService that deletes an admin by ID if they exist. If the ID does not exist, the method throws a AdminNotFoundByIdException.
- Custom Exception Handling: Enhanced AdminExceptionHandler to catch AdminNotFoundByIdException and return a 404 Not Found status with a descriptive error message.
- Consistent Response Structure: Used ErrorStructure and AppResponseBuilder to return a structured response for both successful and failed delete operations:
Success: Returns 200 OK with a success message.
Failure: Returns 404 Not Found with an error structure:
statuscode: 404
message: "Failed to find the user"
rootCause: "User is not found by id"